### PR TITLE
version upgrade\

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "license": "ISC",
   "dependencies": {
     "@grpc/proto-loader": "^0.5.4",
-    "@polkadot/api": "^2.2.1",
-    "@polkadot/types-known": "^2.2.1",
+    "@polkadot/api": "^2.3.1",
+    "@polkadot/types-known": "^2.3.1",
     "@polkadot/util": "^2.18.1",
     "@substrate/calc": "file:vendor/polkadot-calc",
     "google-protobuf": "^3.11.4",


### PR DESCRIPTION
https://www.notion.so/figmentnetworks/Error-in-Polkadot-proxy-26d058cdc28c4ae9835710679d1d2c1a

As we have talked there is a problem when we tunnel to remote node for the height 2017533. We decided to redeploy the services with newer version,