### PR TITLE
Check if runtime version supports fee calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ npm run test:all
 - `PORT` - API port [default: 50051]
 - `NODE_URL` - Polkadot node URL [default: ws://localhost:9944]
 - `ROLLBAR_TOKEN` - Rollbar token for error reporting
+- `MIN_CALCFEE_RUNTIME` - min runtime version where fee calcs are supported
 
 ## Endpoints
 | Service                     | Method          | Description                                                   | Params                                                                  |

--- a/handlers/transaction_handlers.js
+++ b/handlers/transaction_handlers.js
@@ -35,7 +35,7 @@ const getByHeight = async (api, call, context = {}) => {
 
   let calcFee;
   try {
-    calcFee = await createCalcFee(api,api.registry, rawMetadata, rawVersion, rawMultiplier);
+    calcFee = await createCalcFee(api, api.registry, rawMetadata, rawVersion, rawMultiplier);
   } catch(err) {
     rollbar.error(err, {call});
     throw new UnavailableError('could not calculate fee');


### PR DESCRIPTION
Adds new env var `MIN_CALCFEE_RUNTIME`


value for westend should be set to 6:
https://github.com/paritytech/substrate-api-sidecar/blob/master/src/chains-config/westendControllers.ts#L30